### PR TITLE
build: adding plugin to avoid yarn auto-formatting

### DIFF
--- a/.github/workflows/test-flow.yaml
+++ b/.github/workflows/test-flow.yaml
@@ -104,3 +104,13 @@ jobs:
         run: |
           pip install -r docs/requirements.txt
           mkdocs build --strict
+  # easy to require end cap job
+  done:
+    needs:
+      - ensure-docs
+      - ci-checks
+    runs-on: ubuntu-latest
+    name: Done
+    steps:
+      - run: exit 1
+        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')) }}

--- a/.yarn/plugins/correct-yarn-formatting.cjs
+++ b/.yarn/plugins/correct-yarn-formatting.cjs
@@ -1,0 +1,76 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.name = void 0;
+exports.factory = factory;
+exports.name = "correct-yarn-formatting";
+const configuration = {
+    correctFormattingLogs: {
+        description: "Can be used to set the verbosity of the plugin's logs.\n debug - shows everything \n notice - only shows a notice when the plugin stops a bad format and links to the feature request\n none - shows nothing",
+        type: "STRING",
+        default: "notice",
+    },
+};
+class Logger {
+    constructor(project) {
+        this.logLevel =
+            project.configuration.get("correctFormattingLogs") || "notice";
+    }
+    log(msg) {
+        if (this.logLevel === "none")
+            return;
+        console.log(`[${exports.name}] ${msg}`);
+    }
+    debug(msg) {
+        if (this.logLevel !== "debug")
+            return;
+        this.log(msg);
+    }
+    notice(msg) {
+        if (this.logLevel === "notice" || this.logLevel === "debug") {
+            this.log(msg);
+        }
+    }
+}
+function factory(_require) {
+    const { readFileSync, writeFileSync } = _require("fs");
+    const { join } = _require("path");
+    const origPkgs = [];
+    return {
+        configuration,
+        hooks: {
+            validateProject(project) {
+                const logger = new Logger(project);
+                const topPkgJsonPath = join(project.cwd, "package.json");
+                logger.debug(`Reading pre-formatted file: ${topPkgJsonPath}`);
+                origPkgs.push([
+                    topPkgJsonPath,
+                    readFileSync(topPkgJsonPath).toString(),
+                ]);
+                project.workspaces.forEach((w) => {
+                    const pkgJsonPath = join(w.cwd, "package.json");
+                    logger.debug(`Reading pre-formatted file: ${pkgJsonPath}`);
+                    origPkgs.push([pkgJsonPath, readFileSync(pkgJsonPath).toString()]);
+                });
+            },
+            afterAllInstalled(project) {
+                const logger = new Logger(project);
+                let reset = false;
+                origPkgs.forEach(([path, origPkgStr]) => {
+                    const curPkgStr = readFileSync(path).toString();
+                    if (origPkgStr &&
+                        origPkgStr !== curPkgStr &&
+                        // Simple equivalence by reserializing the exact same way
+                        JSON.stringify(JSON.parse(curPkgStr)) ===
+                            JSON.stringify(JSON.parse(origPkgStr))) {
+                        writeFileSync(path, origPkgStr);
+                        logger.debug(`Resetting unnecessary format for ${path}`);
+                        reset = true;
+                    }
+                });
+                if (reset) {
+                    logger.notice("Resetting unnecessary formatting by yarn!\n\tIf you would like this to be a main feature please comment here: https://github.com/yarnpkg/berry/discussions/2636");
+                }
+            },
+        },
+    };
+}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,3 +10,6 @@ plugins:
   - checksum: 0a2a35fbed2f33f0df1ceb1db51bf72554201f994eaecb86cbc62a295c3d05f7cc44fa8be8e64fc5e1c0bee4f529a17a0cc429ea9e3486ad467443291d5a8e3b
     path: .yarn/plugins/@yarnpkg/plugin-after-install.cjs
     spec: "https://raw.githubusercontent.com/mhassan1/yarn-plugin-after-install/refs/tags/v0.6.0/bundles/%40yarnpkg/plugin-after-install.js"
+  - checksum: dd1402820c9f1be4f23995511109ef5110d44502498f59e7f637d6771bce032aafffba0042842f4c9cd3ea5fc4faa0cafdad023cfbd554aa2f1f4bb00711b3fb
+    path: .yarn/plugins/correct-yarn-formatting.cjs
+    spec: "https://raw.githubusercontent.com/HanseltimeIndustries/correct-yarn-formatting/v1.0.1/lib/index.js"

--- a/docs/User Guide/4-corepack.md
+++ b/docs/User Guide/4-corepack.md
@@ -1,6 +1,6 @@
 # Corepack
 
-To keep track of which package managers are running which projects, pkgtest uses (corepack)[https://www.npmjs.com/package/corepack].
+To keep track of which package managers are running which projects, pkgtest uses [corepack](https://www.npmjs.com/package/corepack).
 
 Corepack has historically been bundled with NodeJS, but is not guaranteed to always be bundled with NodeJS.  Additionally, there
 are some issues with expired package keys when corepack is downloading package managers.


### PR DESCRIPTION
# Summary

This solves the problem of yarn unnecessarily formatting package.json at odds with biome