### PR TITLE
build: format after npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
 		"import": "./dist/esm/index.mjs",
 		"default": "./dist/esm/index.mjs"
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"dependencies": {
 		"@inquirer/prompts": "^7.3.2",
 		"chalk": "^5.4.1",

--- a/release.config.js
+++ b/release.config.js
@@ -18,6 +18,7 @@ module.exports = {
 		"@semantic-release/commit-analyzer",
 		"@semantic-release/release-notes-generator",
 		"@semantic-release/changelog",
+		"@semantic-release/npm",
 		// format any changed files
 		[
 			"@semantic-release/exec",
@@ -25,7 +26,6 @@ module.exports = {
 				prepareCmd: "yarn format --fix",
 			},
 		],
-		"@semantic-release/npm",
 		[
 			"@semantic-release/git",
 			{


### PR DESCRIPTION
Performs formatting after npm command to avoid failing formatting