### PR TITLE
feat: adding exit code and log testing for script tests

### DIFF
--- a/docs/api/interfaces/ScriptTestConfig.md
+++ b/docs/api/interfaces/ScriptTestConfig.md
@@ -40,6 +40,8 @@ The expected exit code this script should yield
 If supplied, this will check to see if the stderr of the script matches the provided
 Regex string or lambda and will only pass if it returns true
 
+WARNING - Does not work on Windows. It eats output from stdout and stderr on npm and pnpm run
+
 ***
 
 ### stdoutMatch?
@@ -48,3 +50,5 @@ Regex string or lambda and will only pass if it returns true
 
 If supplied, this will check to see if the stdout of the script matches the provided
 Regex string or lambda and will only pass if it returns true
+
+WARNING - Does not work on Windows. It eats output from stdout and stderr on npm and pnpm run

--- a/docs/api/interfaces/ScriptTestConfig.md
+++ b/docs/api/interfaces/ScriptTestConfig.md
@@ -12,6 +12,15 @@ They will ultimately be run by <package manager> <script>
 
 ## Properties
 
+### exitCode?
+
+> `optional` **exitCode**: `number`
+
+The expected exit code this script should yield
+(defaults to 0)
+
+***
+
 ### name
 
 > **name**: `string`
@@ -21,3 +30,21 @@ They will ultimately be run by <package manager> <script>
 ### script
 
 > **script**: `string`
+
+***
+
+### stderrMatch?
+
+> `optional` **stderrMatch**: `string` \| (`stderr`) => `boolean`
+
+If supplied, this will check to see if the stderr of the script matches the provided
+Regex string or lambda and will only pass if it returns true
+
+***
+
+### stdoutMatch?
+
+> `optional` **stdoutMatch**: `string` \| (`stdout`) => `boolean`
+
+If supplied, this will check to see if the stdout of the script matches the provided
+Regex string or lambda and will only pass if it returns true

--- a/pkgtest.config.js
+++ b/pkgtest.config.js
@@ -143,6 +143,17 @@ const nonNestedTests = {
       name: "hello",
       script: "node -e 'console.log(\"hello\")'",
     },
+    // exitCode functionality
+    {
+      name: "exitCodeFunctionality",
+      script: "node -e 'process.exit(1)'",
+      exitCode: 1,
+    },
+    {
+      name: 'stdoutMatch',
+      script: "node -e 'console.log(\"hey\")'",
+      stdoutMatch: 'he.+'
+    }
   ],
   packageManagers,
   moduleTypes: ["commonjs", "esm"],

--- a/pkgtest.config.js
+++ b/pkgtest.config.js
@@ -150,10 +150,10 @@ const nonNestedTests = {
       exitCode: 1,
     },
     {
-      name: 'stdoutMatch',
+      name: "stdoutMatch",
       script: "node -e 'console.log(\"hey\")'",
-      stdoutMatch: 'he.+'
-    }
+      stdoutMatch: "he.+",
+    },
   ],
   packageManagers,
   moduleTypes: ["commonjs", "esm"],

--- a/pkgtest.config.js
+++ b/pkgtest.config.js
@@ -149,11 +149,16 @@ const nonNestedTests = {
       script: "node -e 'process.exit(1)'",
       exitCode: 1,
     },
-    {
-      name: "stdoutMatch",
-      script: "node -e 'console.log(\"hey\")'",
-      stdoutMatch: "he.+",
-    },
+    // BUG - Windows running does not write out the stdout...
+    ...(process.env !== "win32"
+      ? [
+          {
+            name: "stdoutMatch",
+            script: "node -e 'console.log(\"hey\")'",
+            stdoutMatch: "he.+",
+          },
+        ]
+      : []),
   ],
   packageManagers,
   moduleTypes: ["commonjs", "esm"],

--- a/src/config.ts
+++ b/src/config.ts
@@ -146,7 +146,7 @@ const AddFilePerTestProjectCreateValidated = z
 	.args(z.any(), z.any())
 	.returns(z.any()) satisfies ZodType<AddFilePerTestProjectCreate>;
 
-const LogMatchFunction = z.function().args(z.string()).returns(z.boolean())
+const LogMatchFunction = z.function().args(z.string()).returns(z.boolean());
 
 const ScriptTestConfigValidated = z.object({
 	name: z.string(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -146,9 +146,14 @@ const AddFilePerTestProjectCreateValidated = z
 	.args(z.any(), z.any())
 	.returns(z.any()) satisfies ZodType<AddFilePerTestProjectCreate>;
 
+const LogMatchFunction = z.function().args(z.string()).returns(z.boolean())
+
 const ScriptTestConfigValidated = z.object({
 	name: z.string(),
 	script: z.string(),
+	exitCode: z.number().optional(),
+	stdoutMatch: z.union([z.string(), LogMatchFunction]).optional(),
+	stderrMatch: z.union([z.string(), LogMatchFunction]).optional(),
 }) satisfies ZodType<ScriptTestConfig>;
 
 const TestConfigEntryValidated = z.object({

--- a/src/createTestProject.ts
+++ b/src/createTestProject.ts
@@ -18,6 +18,7 @@ import {
 	getPkgBinaryRunnerCommand,
 	getPkgManagerSetCommand,
 	getPkgScriptRunnerCommand,
+	getStdioPrefilter,
 	sanitizeEnv,
 } from "./pkgManager";
 import { BinTestRunner, FileTestRunner, ScriptTestRunner } from "./runners";
@@ -334,6 +335,7 @@ export async function createTestProject<PkgManagerT extends PkgManager>(
 
 	const fileTestRunners: FileTestRunner[] = [];
 	const binRunCmd = getPkgBinaryRunnerCommand(pkgManager, pkgManagerVersion);
+	const stdioPrefixFilter = getStdioPrefilter(pkgManager);
 
 	// Create fileTests if necessary
 	if (fileTests) {
@@ -460,6 +462,7 @@ export async function createTestProject<PkgManagerT extends PkgManager>(
 						reporter,
 						baseEnv: sanitizedEnv,
 						entryAlias,
+						stdioPrefixFilter,
 					}),
 				);
 			});
@@ -491,6 +494,7 @@ export async function createTestProject<PkgManagerT extends PkgManager>(
 						reporter,
 						baseEnv: sanitizedEnv,
 						entryAlias,
+						stdioPrefixFilter,
 					}),
 				);
 			});
@@ -512,6 +516,7 @@ export async function createTestProject<PkgManagerT extends PkgManager>(
 			reporter,
 			baseEnv: sanitizedEnv,
 			entryAlias,
+			stdioPrefixFilter,
 		});
 	}
 
@@ -529,6 +534,7 @@ export async function createTestProject<PkgManagerT extends PkgManager>(
 			reporter,
 			baseEnv: sanitizedEnv,
 			entryAlias,
+			stdioPrefixFilter,
 		});
 	}
 

--- a/src/pkgManager/getStdioPrefilter.ts
+++ b/src/pkgManager/getStdioPrefilter.ts
@@ -1,0 +1,46 @@
+import { PkgManager } from "../types";
+
+/**
+ * When using corepack to run things, corepack will add some additional lines of
+ * text, which can break stdio match checks
+ *
+ * yarn v1:
+ *  yarn run v1.22.22\n$ node -e 'console.log("hello")'\n
+ * npm:
+ *  \n> @dummy-test-package/test-commonjs@0.0.0 hello /tmp/pkgtest-zDybkv\n> node -e 'console.log("hello")'\n
+ * pnpm:
+ *  \n> @dummy-test-package/test-commonjs@0.0.0 hello\n> node -e 'console.log("hello")'\n
+ */
+export function getStdioPrefilter(pkgManager: PkgManager) {
+	switch (pkgManager) {
+		case PkgManager.Npm:
+		case PkgManager.Pnpm:
+			return (s: string) => {
+				if (s.startsWith("\n>")) {
+					const secondLine = s.indexOf("\n>", 1);
+					if (secondLine > 2) {
+						const lastLine = s.indexOf("\n", secondLine + 1);
+						if (lastLine > secondLine) return lastLine + 1;
+					}
+				}
+				return 0;
+			};
+		case PkgManager.YarnV1:
+			return (s: string) => {
+				if (s.startsWith("yarn ")) {
+					const secondLine = s.indexOf("\n$", 1);
+					if (secondLine > 2) {
+						const lastLine = s.indexOf("\n", secondLine + 1);
+						if (lastLine > secondLine) return lastLine + 1;
+					}
+				}
+				return 0;
+			};
+		case PkgManager.YarnBerry:
+			return undefined;
+		default:
+			throw new Error(
+				`Unimplemented pkg binary runner command for ${pkgManager}`,
+			);
+	}
+}

--- a/src/pkgManager/index.ts
+++ b/src/pkgManager/index.ts
@@ -11,3 +11,4 @@ export * from "./preinstallLatest";
 export * from "./resolveLatestVersions";
 export * from "./sanitizeEnv";
 export * from "./getLocalPackagePath";
+export * from "./getStdioPrefilter";

--- a/src/runners/BaseTestRunner.ts
+++ b/src/runners/BaseTestRunner.ts
@@ -106,6 +106,11 @@ export abstract class BaseTestRunner<RunTArgs> {
 						}
 						if (!shouldFail) {
 							if (stdoutMatch) {
+								if (process.platform === "win32") {
+									console.warn(
+										"WARNING: Windows bug does not get stdout and stderr on (p)npm run some times for stdoutMatch",
+									);
+								}
 								if (this.stdioPrefixFilter) {
 									shouldFail = !stdoutMatch(
 										stdout.substring(this.stdioPrefixFilter(stdout)),
@@ -117,7 +122,11 @@ export abstract class BaseTestRunner<RunTArgs> {
 						}
 						if (!shouldFail) {
 							if (stderrMatch) {
-								shouldFail = !stderrMatch(stderr);
+								if (process.platform === "win32") {
+									console.warn(
+										"WARNING: Windows bug does not get stdout and stderr on (p)npm run some times for stdoutMatch",
+									);
+								}
 								if (this.stdioPrefixFilter) {
 									shouldFail = !stderrMatch(
 										stderr.substring(this.stdioPrefixFilter(stderr)),

--- a/src/runners/BaseTestRunner.ts
+++ b/src/runners/BaseTestRunner.ts
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { exec, ExecException } from "child_process";
 import { TestGroupOverview, Reporter, TestDescriptor } from "../reporters";
 import { FailFastError, ModuleTypes, PkgManager } from "../types";
 import { ExecExit, ILogFilesScanner } from "../logging";
@@ -61,11 +61,18 @@ export abstract class BaseTestRunner<RunTArgs> {
 			env: {
 				[k: string]: string | undefined;
 			};
+			/**
+			 * The passing exitCode
+			 */
+			exitCode?: number
+			stdoutMatch?: (stdout: string) => boolean
+			stderrMatch?: (stderr: string) => boolean
 		},
 		logFilesScanner?: ILogFilesScanner,
 	): Promise<boolean> {
 		try {
 			const start = new Date();
+			const { exitCode, stderrMatch, stdoutMatch } = opts;
 			await new Promise<void>((res, rej) => {
 				exec(
 					binCmd,
@@ -79,7 +86,28 @@ export abstract class BaseTestRunner<RunTArgs> {
 					},
 					(err, stdout, stderr) => {
 						const testTimeMs = new Date().getTime() - start.getTime();
+						// Advanced pass-fail
+						let shouldFail: boolean = false;
 						if (err) {
+							if (exitCode) {
+								if (exitCode && (err as ExecException).code !== exitCode) {
+									shouldFail = true;
+								}
+							} else {
+								shouldFail = true;
+							}
+						}
+						if (!shouldFail) {
+							if (stdoutMatch) {
+								shouldFail = !stdoutMatch(stdout);
+							}
+						}
+						if (!shouldFail) {
+							if (stderrMatch) {
+								shouldFail = !stderrMatch(stderr);
+							}
+						}
+						if (shouldFail) {
 							this.groupOverview.fail(1);
 							this.reporter.failed({
 								testCmd: binCmd,

--- a/src/runners/BaseTestRunner.ts
+++ b/src/runners/BaseTestRunner.ts
@@ -15,6 +15,7 @@ export interface BaseTestRunnerOptions {
 	pkgManagerAlias: string;
 	modType: ModuleTypes;
 	entryAlias: string;
+	stdioPrefixFilter?: (s: string) => number;
 }
 
 export abstract class BaseTestRunner<RunTArgs> {
@@ -24,6 +25,11 @@ export abstract class BaseTestRunner<RunTArgs> {
 	readonly failFast: boolean;
 	protected readonly reporter: Reporter;
 	readonly pkgManager: PkgManager;
+	/**
+	 * This is used because corepack adds additional information at the beginning of stdout that
+	 * could cause false positives
+	 */
+	protected readonly stdioPrefixFilter?: (s: string) => number;
 	/**
 	 * An alias for the pkg manager configuration for this test suite.
 	 *
@@ -46,6 +52,7 @@ export abstract class BaseTestRunner<RunTArgs> {
 		this.pkgManagerAlias = options.pkgManagerAlias;
 		this.modType = options.modType;
 		this.entryAlias = options.entryAlias;
+		this.stdioPrefixFilter = options.stdioPrefixFilter;
 	}
 
 	/**
@@ -64,9 +71,9 @@ export abstract class BaseTestRunner<RunTArgs> {
 			/**
 			 * The passing exitCode
 			 */
-			exitCode?: number
-			stdoutMatch?: (stdout: string) => boolean
-			stderrMatch?: (stderr: string) => boolean
+			exitCode?: number;
+			stdoutMatch?: (stdout: string) => boolean;
+			stderrMatch?: (stderr: string) => boolean;
 		},
 		logFilesScanner?: ILogFilesScanner,
 	): Promise<boolean> {
@@ -99,12 +106,25 @@ export abstract class BaseTestRunner<RunTArgs> {
 						}
 						if (!shouldFail) {
 							if (stdoutMatch) {
-								shouldFail = !stdoutMatch(stdout);
+								if (this.stdioPrefixFilter) {
+									shouldFail = !stdoutMatch(
+										stdout.substring(this.stdioPrefixFilter(stdout)),
+									);
+								} else {
+									shouldFail = !stdoutMatch(stdout);
+								}
 							}
 						}
 						if (!shouldFail) {
 							if (stderrMatch) {
 								shouldFail = !stderrMatch(stderr);
+								if (this.stdioPrefixFilter) {
+									shouldFail = !stderrMatch(
+										stderr.substring(this.stdioPrefixFilter(stderr)),
+									);
+								} else {
+									shouldFail = !stderrMatch(stderr);
+								}
 							}
 						}
 						if (shouldFail) {

--- a/src/runners/ScriptTestRunner.test.ts
+++ b/src/runners/ScriptTestRunner.test.ts
@@ -466,43 +466,43 @@ describe.each([[true], [false]])(
 				).not.toHaveBeenCalled();
 			}
 		});
-		
+
 		it("evaluates exitCode tests", async () => {
 			mockExec.mockImplementation((cmd, _opts, cb) => {
 				if (!cb) {
 					throw new Error("Did not expect an undefined callback!");
 				}
 				setTimeout(() => {
-						cb(
-							new MockExecException({
-								message: "failure",
-								code: 2,
-							}),
-							testStdOutOnErr,
-							testStdErr,
-						);
+					cb(
+						new MockExecException({
+							message: "failure",
+							code: 2,
+						}),
+						testStdOutOnErr,
+						testStdErr,
+					);
 				}, 10);
 				// Return null for now since we don't use the return process value
 				return null as any;
 			});
-			const script = 'something';
+			const script = "something";
 			const runner = new ScriptTestRunner({
 				runCommand: "npm run",
 				projectDir: testProjectDir,
 				pkgManager: PkgManager.Npm,
 				pkgManagerAlias: "myalias",
 				modType: ModuleTypes.Commonjs,
-				scriptTests:[
+				scriptTests: [
 					{
-						name: 'test1',
+						name: "test1",
 						script,
 						exitCode: 1,
 					},
 					{
-						name: 'test2',
+						name: "test2",
 						script,
 						exitCode: 2,
-					}
+					},
 				],
 				timeout: 5000,
 				reporter: mockReporter,
@@ -527,7 +527,7 @@ describe.each([[true], [false]])(
 			expect(mockReporter.failed).toHaveBeenCalledWith({
 				testCmd: `npm run test1`,
 				test: {
-					name: 'test1',
+					name: "test1",
 				},
 				time: expect.any(Number),
 				stdout: testStdOutOnErr,
@@ -551,43 +551,39 @@ describe.each([[true], [false]])(
 					throw new Error("Did not expect an undefined callback!");
 				}
 				setTimeout(() => {
-						cb(
-							null,
-							testStdOutNormal,
-							"",
-						);
+					cb(null, testStdOutNormal, "");
 				}, 10);
 				// Return null for now since we don't use the return process value
 				return null as any;
 			});
-			const script = 'something';
+			const script = "something";
 			const runner = new ScriptTestRunner({
 				runCommand: "npm run",
 				projectDir: testProjectDir,
 				pkgManager: PkgManager.Npm,
 				pkgManagerAlias: "myalias",
 				modType: ModuleTypes.Commonjs,
-				scriptTests:[
+				scriptTests: [
 					{
-						name: 'test1',
+						name: "test1",
 						script,
-						stdoutMatch: 'norma.+',
+						stdoutMatch: "norma.+",
 					},
 					{
-						name: 'test2',
+						name: "test2",
 						script,
-						stdoutMatch: (log: string) => log.includes('normal'),
+						stdoutMatch: (log: string) => log.includes("normal"),
 					},
 					{
-						name: 'test3',
+						name: "test3",
 						script,
-						stdoutMatch: 'abnorma.+',
+						stdoutMatch: "abnorma.+",
 					},
 					{
-						name: 'test4',
+						name: "test4",
 						script,
-						stdoutMatch: (log: string) => log.includes('abnormal'),
-					}
+						stdoutMatch: (log: string) => log.includes("abnormal"),
+					},
 				],
 				timeout: 5000,
 				reporter: mockReporter,
@@ -615,7 +611,7 @@ describe.each([[true], [false]])(
 				},
 				time: expect.any(Number),
 				stdout: testStdOutNormal,
-				stderr: '',
+				stderr: "",
 			});
 			expect(mockReporter.passed).toHaveBeenCalledWith({
 				testCmd: `npm run test2`,
@@ -624,26 +620,26 @@ describe.each([[true], [false]])(
 				},
 				time: expect.any(Number),
 				stdout: testStdOutNormal,
-				stderr: '',
+				stderr: "",
 			});
 			expect(mockReporter.failed).toHaveBeenCalledWith({
 				testCmd: `npm run test3`,
 				test: {
-					name: 'test3',
+					name: "test3",
 				},
 				time: expect.any(Number),
 				stdout: testStdOutNormal,
-				stderr: '',
+				stderr: "",
 				timedout: false,
 			});
 			expect(mockReporter.failed).toHaveBeenCalledWith({
 				testCmd: `npm run test4`,
 				test: {
-					name: 'test4',
+					name: "test4",
 				},
 				time: expect.any(Number),
 				stdout: testStdOutNormal,
-				stderr: '',
+				stderr: "",
 				timedout: false,
 			});
 		});
@@ -654,43 +650,39 @@ describe.each([[true], [false]])(
 					throw new Error("Did not expect an undefined callback!");
 				}
 				setTimeout(() => {
-						cb(
-							null,
-							"",
-							testStdOutNormal,
-						);
+					cb(null, "", testStdOutNormal);
 				}, 10);
 				// Return null for now since we don't use the return process value
 				return null as any;
 			});
-			const script = 'something';
+			const script = "something";
 			const runner = new ScriptTestRunner({
 				runCommand: "npm run",
 				projectDir: testProjectDir,
 				pkgManager: PkgManager.Npm,
 				pkgManagerAlias: "myalias",
 				modType: ModuleTypes.Commonjs,
-				scriptTests:[
+				scriptTests: [
 					{
-						name: 'test1',
+						name: "test1",
 						script,
-						stderrMatch: 'norma.+',
+						stderrMatch: "norma.+",
 					},
 					{
-						name: 'test2',
+						name: "test2",
 						script,
-						stderrMatch: (log: string) => log.includes('normal'),
+						stderrMatch: (log: string) => log.includes("normal"),
 					},
 					{
-						name: 'test3',
+						name: "test3",
 						script,
-						stderrMatch: 'abnorma.+',
+						stderrMatch: "abnorma.+",
 					},
 					{
-						name: 'test4',
+						name: "test4",
 						script,
-						stderrMatch: (log: string) => log.includes('abnormal'),
-					}
+						stderrMatch: (log: string) => log.includes("abnormal"),
+					},
 				],
 				timeout: 5000,
 				reporter: mockReporter,
@@ -717,7 +709,7 @@ describe.each([[true], [false]])(
 					name: "test1",
 				},
 				time: expect.any(Number),
-				stdout: '',
+				stdout: "",
 				stderr: testStdOutNormal,
 			});
 			expect(mockReporter.passed).toHaveBeenCalledWith({
@@ -726,26 +718,26 @@ describe.each([[true], [false]])(
 					name: "test2",
 				},
 				time: expect.any(Number),
-				stdout: '',
+				stdout: "",
 				stderr: testStdOutNormal,
 			});
 			expect(mockReporter.failed).toHaveBeenCalledWith({
 				testCmd: `npm run test3`,
 				test: {
-					name: 'test3',
+					name: "test3",
 				},
 				time: expect.any(Number),
-				stdout: '',
+				stdout: "",
 				stderr: testStdOutNormal,
 				timedout: false,
 			});
 			expect(mockReporter.failed).toHaveBeenCalledWith({
 				testCmd: `npm run test4`,
 				test: {
-					name: 'test4',
+					name: "test4",
 				},
 				time: expect.any(Number),
-				stdout: '',
+				stdout: "",
 				stderr: testStdOutNormal,
 				timedout: false,
 			});

--- a/src/runners/ScriptTestRunner.test.ts
+++ b/src/runners/ScriptTestRunner.test.ts
@@ -466,6 +466,290 @@ describe.each([[true], [false]])(
 				).not.toHaveBeenCalled();
 			}
 		});
+		
+		it("evaluates exitCode tests", async () => {
+			mockExec.mockImplementation((cmd, _opts, cb) => {
+				if (!cb) {
+					throw new Error("Did not expect an undefined callback!");
+				}
+				setTimeout(() => {
+						cb(
+							new MockExecException({
+								message: "failure",
+								code: 2,
+							}),
+							testStdOutOnErr,
+							testStdErr,
+						);
+				}, 10);
+				// Return null for now since we don't use the return process value
+				return null as any;
+			});
+			const script = 'something';
+			const runner = new ScriptTestRunner({
+				runCommand: "npm run",
+				projectDir: testProjectDir,
+				pkgManager: PkgManager.Npm,
+				pkgManagerAlias: "myalias",
+				modType: ModuleTypes.Commonjs,
+				scriptTests:[
+					{
+						name: 'test1',
+						script,
+						exitCode: 1,
+					},
+					{
+						name: 'test2',
+						script,
+						exitCode: 2,
+					}
+				],
+				timeout: 5000,
+				reporter: mockReporter,
+				baseEnv: process.env,
+				entryAlias: testEntryAlias,
+			});
+
+			const overview = await runner.runTests({
+				logFilesScanner,
+			});
+			overviewEqual(overview, {
+				passed: 1,
+				failed: 1,
+				skipped: 0,
+				notReached: 0,
+				total: 2,
+				failedFast: false,
+			});
+			expect(overview.time).toBeGreaterThan(1);
+
+			// One should have passed, one failed
+			expect(mockReporter.failed).toHaveBeenCalledWith({
+				testCmd: `npm run test1`,
+				test: {
+					name: 'test1',
+				},
+				time: expect.any(Number),
+				stdout: testStdOutOnErr,
+				stderr: testStdErr,
+				timedout: false,
+			});
+			expect(mockReporter.passed).toHaveBeenCalledWith({
+				testCmd: `npm run test2`,
+				test: {
+					name: "test2",
+				},
+				time: expect.any(Number),
+				stdout: testStdOutOnErr,
+				stderr: testStdErr,
+			});
+		});
+
+		it("evaluates stdoutMatch tests", async () => {
+			mockExec.mockImplementation((cmd, _opts, cb) => {
+				if (!cb) {
+					throw new Error("Did not expect an undefined callback!");
+				}
+				setTimeout(() => {
+						cb(
+							null,
+							testStdOutNormal,
+							"",
+						);
+				}, 10);
+				// Return null for now since we don't use the return process value
+				return null as any;
+			});
+			const script = 'something';
+			const runner = new ScriptTestRunner({
+				runCommand: "npm run",
+				projectDir: testProjectDir,
+				pkgManager: PkgManager.Npm,
+				pkgManagerAlias: "myalias",
+				modType: ModuleTypes.Commonjs,
+				scriptTests:[
+					{
+						name: 'test1',
+						script,
+						stdoutMatch: 'norma.+',
+					},
+					{
+						name: 'test2',
+						script,
+						stdoutMatch: (log: string) => log.includes('normal'),
+					},
+					{
+						name: 'test3',
+						script,
+						stdoutMatch: 'abnorma.+',
+					},
+					{
+						name: 'test4',
+						script,
+						stdoutMatch: (log: string) => log.includes('abnormal'),
+					}
+				],
+				timeout: 5000,
+				reporter: mockReporter,
+				baseEnv: process.env,
+				entryAlias: testEntryAlias,
+			});
+
+			const overview = await runner.runTests({
+				logFilesScanner,
+			});
+			overviewEqual(overview, {
+				passed: 2,
+				failed: 2,
+				skipped: 0,
+				notReached: 0,
+				total: 4,
+				failedFast: false,
+			});
+			expect(overview.time).toBeGreaterThan(1);
+
+			expect(mockReporter.passed).toHaveBeenCalledWith({
+				testCmd: `npm run test1`,
+				test: {
+					name: "test1",
+				},
+				time: expect.any(Number),
+				stdout: testStdOutNormal,
+				stderr: '',
+			});
+			expect(mockReporter.passed).toHaveBeenCalledWith({
+				testCmd: `npm run test2`,
+				test: {
+					name: "test2",
+				},
+				time: expect.any(Number),
+				stdout: testStdOutNormal,
+				stderr: '',
+			});
+			expect(mockReporter.failed).toHaveBeenCalledWith({
+				testCmd: `npm run test3`,
+				test: {
+					name: 'test3',
+				},
+				time: expect.any(Number),
+				stdout: testStdOutNormal,
+				stderr: '',
+				timedout: false,
+			});
+			expect(mockReporter.failed).toHaveBeenCalledWith({
+				testCmd: `npm run test4`,
+				test: {
+					name: 'test4',
+				},
+				time: expect.any(Number),
+				stdout: testStdOutNormal,
+				stderr: '',
+				timedout: false,
+			});
+		});
+
+		it("evaluates stderrMatch tests", async () => {
+			mockExec.mockImplementation((cmd, _opts, cb) => {
+				if (!cb) {
+					throw new Error("Did not expect an undefined callback!");
+				}
+				setTimeout(() => {
+						cb(
+							null,
+							"",
+							testStdOutNormal,
+						);
+				}, 10);
+				// Return null for now since we don't use the return process value
+				return null as any;
+			});
+			const script = 'something';
+			const runner = new ScriptTestRunner({
+				runCommand: "npm run",
+				projectDir: testProjectDir,
+				pkgManager: PkgManager.Npm,
+				pkgManagerAlias: "myalias",
+				modType: ModuleTypes.Commonjs,
+				scriptTests:[
+					{
+						name: 'test1',
+						script,
+						stderrMatch: 'norma.+',
+					},
+					{
+						name: 'test2',
+						script,
+						stderrMatch: (log: string) => log.includes('normal'),
+					},
+					{
+						name: 'test3',
+						script,
+						stderrMatch: 'abnorma.+',
+					},
+					{
+						name: 'test4',
+						script,
+						stderrMatch: (log: string) => log.includes('abnormal'),
+					}
+				],
+				timeout: 5000,
+				reporter: mockReporter,
+				baseEnv: process.env,
+				entryAlias: testEntryAlias,
+			});
+
+			const overview = await runner.runTests({
+				logFilesScanner,
+			});
+			overviewEqual(overview, {
+				passed: 2,
+				failed: 2,
+				skipped: 0,
+				notReached: 0,
+				total: 4,
+				failedFast: false,
+			});
+			expect(overview.time).toBeGreaterThan(1);
+
+			expect(mockReporter.passed).toHaveBeenCalledWith({
+				testCmd: `npm run test1`,
+				test: {
+					name: "test1",
+				},
+				time: expect.any(Number),
+				stdout: '',
+				stderr: testStdOutNormal,
+			});
+			expect(mockReporter.passed).toHaveBeenCalledWith({
+				testCmd: `npm run test2`,
+				test: {
+					name: "test2",
+				},
+				time: expect.any(Number),
+				stdout: '',
+				stderr: testStdOutNormal,
+			});
+			expect(mockReporter.failed).toHaveBeenCalledWith({
+				testCmd: `npm run test3`,
+				test: {
+					name: 'test3',
+				},
+				time: expect.any(Number),
+				stdout: '',
+				stderr: testStdOutNormal,
+				timedout: false,
+			});
+			expect(mockReporter.failed).toHaveBeenCalledWith({
+				testCmd: `npm run test4`,
+				test: {
+					name: 'test4',
+				},
+				time: expect.any(Number),
+				stdout: '',
+				stderr: testStdOutNormal,
+				timedout: false,
+			});
+		});
 
 		function overviewEqual(
 			overview: TestGroupOverview,

--- a/src/runners/ScriptTestRunner.ts
+++ b/src/runners/ScriptTestRunner.ts
@@ -30,7 +30,7 @@ export class ScriptTestRunner
 			createTestProjectFolderPath(this),
 		);
 		for (let i = 0; i < this.scriptTests.length; i++) {
-			const { name } = this.scriptTests[i];
+			const { name, exitCode, stderrMatch, stdoutMatch } = this.scriptTests[i];
 			const command = `${this.runCommand} ${name}`;
 			const cont = await this.execTest(
 				command,
@@ -40,6 +40,9 @@ export class ScriptTestRunner
 				{
 					// No additional env
 					env: {},
+					exitCode,
+					stderrMatch: stderrMatch ? this.makeStdMatch(stderrMatch) : undefined,
+					stdoutMatch: stdoutMatch ? this.makeStdMatch(stdoutMatch) : undefined,
 				},
 				testLevelScanner?.createNested(`${i}`),
 			);
@@ -52,4 +55,12 @@ export class ScriptTestRunner
 
 		return this.groupOverview;
 	}
+
+	private makeStdMatch(match: string | ((std: string) => boolean)): (std: string) => boolean {
+		if (typeof match === "string") {
+			return (std: string) => !!std.match(new RegExp(match))
+		}
+		return match
+	}
+
 }

--- a/src/runners/ScriptTestRunner.ts
+++ b/src/runners/ScriptTestRunner.ts
@@ -56,11 +56,12 @@ export class ScriptTestRunner
 		return this.groupOverview;
 	}
 
-	private makeStdMatch(match: string | ((std: string) => boolean)): (std: string) => boolean {
+	private makeStdMatch(
+		match: string | ((std: string) => boolean),
+	): (std: string) => boolean {
 		if (typeof match === "string") {
-			return (std: string) => !!std.match(new RegExp(match))
+			return (std: string) => !!std.match(new RegExp(match));
 		}
-		return match
+		return match;
 	}
-
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,11 +252,15 @@ export interface ScriptTestConfig {
 	/**
 	 * If supplied, this will check to see if the stdout of the script matches the provided
 	 * Regex string or lambda and will only pass if it returns true
+	 *
+	 * WARNING - Does not work on Windows. It eats output from stdout and stderr on npm and pnpm run
 	 */
 	stdoutMatch?: string | ((stdout: string) => boolean);
 	/**
 	 * If supplied, this will check to see if the stderr of the script matches the provided
 	 * Regex string or lambda and will only pass if it returns true
+	 *
+	 * WARNING - Does not work on Windows. It eats output from stdout and stderr on npm and pnpm run
 	 */
 	stderrMatch?: string | ((stderr: string) => boolean);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -244,6 +244,21 @@ export interface FileTestConfig {
 export interface ScriptTestConfig {
 	name: string;
 	script: string;
+	/**
+	 * The expected exit code this script should yield
+	 * (defaults to 0)
+	 */
+	exitCode?: number,
+	/**
+	 * If supplied, this will check to see if the stdout of the script matches the provided
+	 * Regex string or lambda and will only pass if it returns true
+	 */
+	stdoutMatch?: string | ((stdout: string) => boolean)
+	/**
+	 * If supplied, this will check to see if the stderr of the script matches the provided
+	 * Regex string or lambda and will only pass if it returns true
+	 */
+	stderrMatch?: string | ((stderr: string) => boolean)
 }
 
 export interface TestConfigEntry {

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,17 +248,17 @@ export interface ScriptTestConfig {
 	 * The expected exit code this script should yield
 	 * (defaults to 0)
 	 */
-	exitCode?: number,
+	exitCode?: number;
 	/**
 	 * If supplied, this will check to see if the stdout of the script matches the provided
 	 * Regex string or lambda and will only pass if it returns true
 	 */
-	stdoutMatch?: string | ((stdout: string) => boolean)
+	stdoutMatch?: string | ((stdout: string) => boolean);
 	/**
 	 * If supplied, this will check to see if the stderr of the script matches the provided
 	 * Regex string or lambda and will only pass if it returns true
 	 */
-	stderrMatch?: string | ((stderr: string) => boolean)
+	stderrMatch?: string | ((stderr: string) => boolean);
 }
 
 export interface TestConfigEntry {


### PR DESCRIPTION
# Summary

This adds the ability for script tests to look for non-zero exit codes and for script tests to be checked for certain logs as well.

It also adds  filter since it turns out corepack is adding logs that could create false positives